### PR TITLE
fix contact numbering for multiple electrodes

### DIFF
--- a/ossdbs/api.py
+++ b/ossdbs/api.py
@@ -158,7 +158,7 @@ def set_contact_and_encapsulation_layer_properties(settings, model_geometry):
         _logger.debug(f"Update Electrode {idx} with settings {new_parameters}")
         if "Contacts" in new_parameters:
             for contact_info in new_parameters["Contacts"]:
-                contact_idx = offset + idx + contact_info["Contact_ID"]
+                contact_idx = offset + contact_info["Contact_ID"]
                 # contacts are zero-indexed in the model_geometry
                 model_geometry.update_contact(contact_idx - 1, contact_info)
             offset += model_geometry.electrodes[idx].n_contacts

--- a/ossdbs/api.py
+++ b/ossdbs/api.py
@@ -158,7 +158,7 @@ def set_contact_and_encapsulation_layer_properties(settings, model_geometry):
         _logger.debug(f"Update Electrode {idx} with settings {new_parameters}")
         if "Contacts" in new_parameters:
             for contact_info in new_parameters["Contacts"]:
-                contact_idx = offset + contact_info["Contact_ID"]
+                contact_idx = offset + idx + contact_info["Contact_ID"]
                 # contacts are zero-indexed in the model_geometry
                 model_geometry.update_contact(contact_idx - 1, contact_info)
             offset += model_geometry.electrodes[idx].n_contacts

--- a/ossdbs/model_geometry/model_geometry.py
+++ b/ossdbs/model_geometry/model_geometry.py
@@ -86,9 +86,9 @@ class ModelGeometry:
             else:
                 brain_geo = brain_geo - electrode.geometry
 
-            brain_surfaces = brain.get_surface_names()
-            for surface in brain_surfaces:
-                self._contacts.append(Contact(name=surface))
+        brain_surfaces = brain.get_surface_names()
+        for surface in brain_surfaces:
+            self._contacts.append(Contact(name=surface))
         try:
             return netgen.occ.OCCGeometry(brain_geo)
         except netgen.occ.OCCException:


### PR DESCRIPTION
When using multiple electrodes, the first contact of the second, third, ... electrode was skipped.
This is fixed now by using the electrode index when numbering