### PR TITLE
FIX: contact.max_h_edge to contact.edge_max_h to set mesh size correctly

### DIFF
--- a/ossdbs/model_geometry/model_geometry.py
+++ b/ossdbs/model_geometry/model_geometry.py
@@ -173,7 +173,7 @@ class ModelGeometry:
                 contact.max_h = value
                 self.set_face_mesh_sizes({contact.name: value})
             elif setting == "MaxMeshSizeEdge":
-                contact.max_h_edge = value
+                contact.edge_max_h = value
                 self.set_edge_mesh_sizes({contact.name: value})
             elif setting in ["Contact_ID", "Name"]:
                 continue


### PR DESCRIPTION
## FIX: contact.max_h_edge to contact.edge_max_h to set mesh size correctly

* In the function update_contact(), the non-existent parameter contact.max_h_edge was set, rather than the actually used parameter contact.edge_max_h; this is fixed now.
* Using stimsets, the max h on the edge is printed and now matching the user-defined input, rather than the fallback value of 1e10.