### PR TITLE
Fix dependency pins: drop numpy<2, pin mkl<2026

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,8 @@ dependencies = ["h5py==3.14.0",
 		# windows has no automated installer
 		"neuron==8.2.7; platform_system=='Linux'", 
 		"neuron==8.2.7; platform_system=='Darwin'", 
-		# if Neuron cannot be installed from Pypi
-		# pin the numpy version to < 2
-		"numpy<2; platform_system=='Windows'",
 		"dipy>=1.8.0",
+		"mkl<2026; platform_system!='Darwin'",
                 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Remove numpy<2 Windows pin: NEURON 8.2.7 works with numpy 2.x, and the pin blocked installation on Python 3.13+ (no wheels).
- Pin mkl<2026 on Linux/Windows: mkl 2026.0.0 ships libmkl_rt.so.2 which breaks ngsolve's shared library loading.
- 
Already released as `0.5.5.post2` on PyPI.

## Test plan
- [x] Verified NEURON 8.2.7 works with numpy 2.4.4 in a clean venv
- [x] CI passes with updated pins