### PR TITLE
Add NEURON activation regression tests for version upgrade safety

### DIFF
--- a/tests/test_neuron_model.py
+++ b/tests/test_neuron_model.py
@@ -560,6 +560,323 @@ class TestMcNeal1976:
         assert os.path.exists(hoc_path)
 
 
+def _point_source_potential(segment_positions, electrode_pos, amplitude):
+    """Compute extracellular potential from a point source in homogeneous medium.
+
+    Uses V = amplitude / (4*pi*sigma*r) with sigma=0.3 S/m.
+    Returns potential in mV for positions in um.
+
+    Parameters
+    ----------
+    segment_positions : np.ndarray
+        (N, 3) array of segment midpoint positions in um.
+    electrode_pos : np.ndarray
+        (3,) electrode position in um.
+    amplitude : float
+        Source amplitude in mV*um (pre-scaled for convenience).
+    """
+    r = np.linalg.norm(segment_positions - electrode_pos, axis=1)
+    r = np.maximum(r, 1.0)  # avoid division by zero
+    return amplitude / r
+
+
+class TestNeuronActivation:
+    """Tests that verify NEURON actually produces action potentials.
+
+    These tests apply known extracellular potentials directly to
+    _run_neuron_simulation and check activation results. They serve as
+    numerical regression tests: if the NEURON version changes (e.g. 8→9),
+    any shift in activation thresholds will be caught here.
+
+    The stimulus is a point-source cathodic pulse placed near the center
+    of the axon, producing a realistic spatial gradient (activating function).
+    """
+
+    @requires_neuron
+    def test_mrg2002_suprathreshold_activates(self, tmp_path):
+        """A cathodic point-source pulse above threshold must trigger an AP.
+
+        Uses default HOC parameters (fiberD=3.0, 75 nodes, 593 compartments,
+        deltax=278 um) to avoid HOC file modifications and mechanism reload issues.
+        """
+        from ossdbs.axon_processing.neuron_model import (
+            MRG2002,
+            _run_neuron_simulation,
+        )
+
+        # Default MRG2002 parameters from axon4pyfull.hoc
+        n_ranvier = 75
+        n_comp = 8  # for fiberD=3.0 (< 5.7): node + MYSA + FLUT + 3*STIN + FLUT + MYSA
+        n_segments = (n_ranvier - 1) * n_comp + 1  # 593
+        deltax = 278.0  # um, default node-to-node spacing
+
+        pathways_dict = {
+            "Axon_Model_Type": "MRG2002",
+            "connectome_name": "test",
+            "axon_diams": [3.0],
+            "n_Ranvier": [n_ranvier],
+            "N_seeded_neurons": [1],
+            "N_orig_neurons": [1],
+        }
+
+        output_path = str(tmp_path / "output")
+        os.makedirs(output_path)
+        simulator = MRG2002(pathways_dict, output_path)
+        # Skip modify_hoc_file — use defaults that match the template
+
+        time_step = 0.005  # ms
+        n_time_steps = 2000  # 10 ms total
+        signal_dict = {"time_step": time_step, "N_time_steps": n_time_steps}
+
+        # Build segment positions along x-axis
+        seg_positions = np.zeros((n_segments, 3))
+        for i in range(n_segments):
+            seg_positions[i, 0] = (i // n_comp) * deltax + (
+                i % n_comp
+            ) * deltax / n_comp
+
+        # Point source 200 um from center of axon
+        center_x = seg_positions[n_segments // 2, 0]
+        electrode_pos = np.array([center_x, 200.0, 0.0])
+
+        # Amplitude 1e5 mV*um — produces ~500 mV at center, AF ~15 mV
+        spatial_potential = _point_source_potential(
+            seg_positions, electrode_pos, amplitude=-1e5
+        )
+
+        v_ext = np.zeros((n_segments, n_time_steps))
+        pulse_start = 20
+        pulse_duration_steps = int(0.2 / time_step)  # 0.2 ms pulse
+        for t in range(pulse_start, pulse_start + pulse_duration_steps):
+            v_ext[:, t] = spatial_potential
+
+        result = _run_neuron_simulation(
+            neuron_index=0,
+            v_ext=v_ext,
+            neuron_workdir=simulator._neuron_workdir,
+            hoc_file=simulator.hoc_file,
+            signal_dict=signal_dict,
+            extra_initialization=simulator._extra_initialization,
+            v_init=simulator._v_init,
+        )
+
+        assert len(result) == 2, f"Simulation error: {result}"
+        assert result[1] is True, "Suprathreshold stimulus must activate axon"
+
+    @requires_neuron
+    def test_mrg2002_subthreshold_does_not_activate(self, tmp_path):
+        """A weak cathodic point-source pulse must NOT trigger an AP."""
+        from ossdbs.axon_processing.neuron_model import (
+            MRG2002,
+            _run_neuron_simulation,
+        )
+
+        n_ranvier = 75
+        n_comp = 8
+        n_segments = (n_ranvier - 1) * n_comp + 1  # 593
+        deltax = 278.0
+
+        pathways_dict = {
+            "Axon_Model_Type": "MRG2002",
+            "connectome_name": "test",
+            "axon_diams": [3.0],
+            "n_Ranvier": [n_ranvier],
+            "N_seeded_neurons": [1],
+            "N_orig_neurons": [1],
+        }
+
+        output_path = str(tmp_path / "output")
+        os.makedirs(output_path)
+        simulator = MRG2002(pathways_dict, output_path)
+
+        time_step = 0.005
+        n_time_steps = 2000
+        signal_dict = {"time_step": time_step, "N_time_steps": n_time_steps}
+
+        seg_positions = np.zeros((n_segments, 3))
+        for i in range(n_segments):
+            seg_positions[i, 0] = (i // n_comp) * deltax + (
+                i % n_comp
+            ) * deltax / n_comp
+
+        center_x = seg_positions[n_segments // 2, 0]
+        electrode_pos = np.array([center_x, 200.0, 0.0])
+
+        # Amplitude 1e3 — ~50x weaker than threshold
+        spatial_potential = _point_source_potential(
+            seg_positions, electrode_pos, amplitude=-1e3
+        )
+
+        v_ext = np.zeros((n_segments, n_time_steps))
+        pulse_start = 20
+        pulse_duration_steps = int(0.2 / time_step)
+        for t in range(pulse_start, pulse_start + pulse_duration_steps):
+            v_ext[:, t] = spatial_potential
+
+        result = _run_neuron_simulation(
+            neuron_index=0,
+            v_ext=v_ext,
+            neuron_workdir=simulator._neuron_workdir,
+            hoc_file=simulator.hoc_file,
+            signal_dict=signal_dict,
+            extra_initialization=simulator._extra_initialization,
+            v_init=simulator._v_init,
+        )
+
+        assert len(result) == 2, f"Simulation error: {result}"
+        assert result[1] is False, "Subthreshold stimulus must not activate axon"
+
+    @requires_neuron
+    def test_mcneal1976_suprathreshold_activates(self, tmp_path):
+        """McNeal1976: a strong cathodic point-source pulse must trigger an AP."""
+        from ossdbs.axon_processing.axon_models import AxonMorphologyMcNeal1976
+        from ossdbs.axon_processing.neuron_model import (
+            McNeal1976,
+            _run_neuron_simulation,
+        )
+
+        n_ranvier = 25
+        n_compartments = n_ranvier * 2 - 1  # 49 (nodes + internodes)
+
+        pathways_dict = {
+            "Axon_Model_Type": "McNeal1976",
+            "connectome_name": "test",
+            "axon_diams": [5.0],
+            "n_Ranvier": [n_ranvier],
+            "N_seeded_neurons": [1],
+            "N_orig_neurons": [1],
+        }
+
+        output_path = str(tmp_path / "output")
+        os.makedirs(output_path)
+        simulator = McNeal1976(pathways_dict, output_path)
+
+        axon_morphology = AxonMorphologyMcNeal1976()
+        axon_morphology.update_axon_morphology(5.0, n_Ranvier=n_ranvier)
+
+        time_step = 0.005
+        n_time_steps = 1000
+        steps_per_ms = int(1.0 / time_step)
+        simulator.modify_hoc_file(n_ranvier, steps_per_ms, axon_morphology)
+
+        signal_dict = {"time_step": time_step, "N_time_steps": n_time_steps}
+
+        # McNeal1976: DIAM=5, ELD=100, so internode length = 500 um
+        # GAP = 2.5 um (node length). Compartments alternate node/internode.
+        internode_length = 500.0  # um
+        node_length = 2.5  # um (GAP * 1e4 in um)
+        seg_positions = np.zeros((n_compartments, 3))
+        x = 0.0
+        for i in range(n_compartments):
+            if i % 2 == 0:  # node
+                seg_positions[i, 0] = x + node_length / 2
+                x += node_length
+            else:  # internode
+                seg_positions[i, 0] = x + internode_length / 2
+                x += internode_length
+
+        center_x = seg_positions[n_compartments // 2, 0]
+        electrode_pos = np.array([center_x, 500.0, 0.0])
+
+        # Strong cathodic pulse
+        spatial_potential = _point_source_potential(
+            seg_positions, electrode_pos, amplitude=-5e6
+        )
+
+        v_ext = np.zeros((n_compartments, n_time_steps))
+        pulse_start = 10
+        pulse_duration_steps = int(0.1 / time_step)
+        for t in range(pulse_start, pulse_start + pulse_duration_steps):
+            v_ext[:, t] = spatial_potential
+
+        result = _run_neuron_simulation(
+            neuron_index=0,
+            v_ext=v_ext,
+            neuron_workdir=simulator._neuron_workdir,
+            hoc_file=simulator.hoc_file,
+            signal_dict=signal_dict,
+            extra_initialization=simulator._extra_initialization,
+            v_init=simulator._v_init,
+        )
+
+        assert len(result) == 2, f"Simulation error: {result}"
+        assert result[1] is True, "Suprathreshold stimulus must activate axon"
+
+    @requires_neuron
+    def test_mcneal1976_subthreshold_does_not_activate(self, tmp_path):
+        """McNeal1976: a weak cathodic point-source pulse must NOT trigger an AP."""
+        from ossdbs.axon_processing.axon_models import AxonMorphologyMcNeal1976
+        from ossdbs.axon_processing.neuron_model import (
+            McNeal1976,
+            _run_neuron_simulation,
+        )
+
+        n_ranvier = 25
+        n_compartments = n_ranvier * 2 - 1
+
+        pathways_dict = {
+            "Axon_Model_Type": "McNeal1976",
+            "connectome_name": "test",
+            "axon_diams": [5.0],
+            "n_Ranvier": [n_ranvier],
+            "N_seeded_neurons": [1],
+            "N_orig_neurons": [1],
+        }
+
+        output_path = str(tmp_path / "output")
+        os.makedirs(output_path)
+        simulator = McNeal1976(pathways_dict, output_path)
+
+        axon_morphology = AxonMorphologyMcNeal1976()
+        axon_morphology.update_axon_morphology(5.0, n_Ranvier=n_ranvier)
+
+        time_step = 0.005
+        n_time_steps = 1000
+        steps_per_ms = int(1.0 / time_step)
+        simulator.modify_hoc_file(n_ranvier, steps_per_ms, axon_morphology)
+
+        signal_dict = {"time_step": time_step, "N_time_steps": n_time_steps}
+
+        internode_length = 500.0
+        node_length = 2.5
+        seg_positions = np.zeros((n_compartments, 3))
+        x = 0.0
+        for i in range(n_compartments):
+            if i % 2 == 0:
+                seg_positions[i, 0] = x + node_length / 2
+                x += node_length
+            else:
+                seg_positions[i, 0] = x + internode_length / 2
+                x += internode_length
+
+        center_x = seg_positions[n_compartments // 2, 0]
+        electrode_pos = np.array([center_x, 500.0, 0.0])
+
+        # Very weak pulse
+        spatial_potential = _point_source_potential(
+            seg_positions, electrode_pos, amplitude=-1e3
+        )
+
+        v_ext = np.zeros((n_compartments, n_time_steps))
+        pulse_start = 10
+        pulse_duration_steps = int(0.1 / time_step)
+        for t in range(pulse_start, pulse_start + pulse_duration_steps):
+            v_ext[:, t] = spatial_potential
+
+        result = _run_neuron_simulation(
+            neuron_index=0,
+            v_ext=v_ext,
+            neuron_workdir=simulator._neuron_workdir,
+            hoc_file=simulator.hoc_file,
+            signal_dict=signal_dict,
+            extra_initialization=simulator._extra_initialization,
+            v_init=simulator._v_init,
+        )
+
+        assert len(result) == 2, f"Simulation error: {result}"
+        assert result[1] is False, "Subthreshold stimulus must not activate axon"
+
+
 class TestMRG2002Upsampling:
     """Tests for MRG2002 upsampling functionality."""
 


### PR DESCRIPTION
Add TestNeuronActivation class with 4 tests that verify action potential generation using point-source extracellular stimulation for both MRG2002 and McNeal1976 axon models. These serve as numerical regression tests to catch threshold shifts when upgrading NEURON (e.g. 8.x → 9.x).