### PR TITLE
PERF: reuse located mesh points in point analysis

### DIFF
--- a/ossdbs/fem/mesh.py
+++ b/ossdbs/fem/mesh.py
@@ -206,7 +206,9 @@ class Mesh:
         """
         x, y, z = points.T
         mips = self._mesh(x, y, z)
-        return np.array([mip[5] == -1 for mip in mips])
+        # mips is a numpy structured array, "nr" is the element number
+        # and -1 marks a point that could not be located in the mesh
+        return mips["nr"] == -1
 
     def refine(self, at_surface: bool = False) -> None:
         """Refine the mesh.

--- a/ossdbs/fem/volume_conductor/volume_conductor_model.py
+++ b/ossdbs/fem/volume_conductor/volume_conductor_model.py
@@ -765,40 +765,56 @@ class VolumeConductor(ABC):
         """Most recent frequency, not equal to the frequency of the signal!."""
         return self._frequency
 
-    def evaluate_potential_at_points(self, lattice: np.ndarray) -> np.ndarray:
+    def evaluate_potential_at_points(
+        self, lattice: np.ndarray, mesh_points=None
+    ) -> np.ndarray:
         """Return electric potential at specifed 3-D coordinates.
 
         Parameters
         ----------
         lattice : np.ndarray
             Nx3 numpy.ndarray of lattice points
+        mesh_points : optional
+            Points of ``lattice`` already located in the mesh, as provided
+            by :attr:`PointModel.mesh_points`. Locating points is the
+            expensive step, so pass this to avoid repeating it.
 
         Notes
         -----
         Requires that points outside of the computational domain
         have been filtered!
         """
-        mesh = self.mesh.ngsolvemesh
-        x, y, z = lattice.T
-        pots = self.potential(mesh(x, y, z))
+        if mesh_points is None:
+            mesh = self.mesh.ngsolvemesh
+            x, y, z = lattice.T
+            mesh_points = mesh(x, y, z)
+        pots = self.potential(mesh_points)
         return pots
 
-    def evaluate_field_at_points(self, lattice: np.ndarray) -> np.ndarray:
+    def evaluate_field_at_points(
+        self, lattice: np.ndarray, mesh_points=None
+    ) -> np.ndarray:
         """Return electric field components at specifed 3-D coordinates.
 
         Parameters
         ----------
         lattice : np.ndarray
             Nx3 numpy.ndarray of lattice points
+        mesh_points : optional
+            Points of ``lattice`` already located in the mesh, as provided
+            by :attr:`PointModel.mesh_points`. Locating points is the
+            expensive step, so pass this to avoid repeating it.
 
         Notes
         -----
         Requires that points outside of the computational domain
         have been filtered!
         """
-        mesh = self.mesh.ngsolvemesh
-        x, y, z = lattice.T
-        fields = self.electric_field(mesh(x, y, z))
+        if mesh_points is None:
+            mesh = self.mesh.ngsolvemesh
+            x, y, z = lattice.T
+            mesh_points = mesh(x, y, z)
+        fields = self.electric_field(mesh_points)
         return fields
 
     @property
@@ -1278,8 +1294,12 @@ class VolumeConductor(ABC):
     ):
         """Copy results to points."""
         for point_model in point_models:
-            potentials = self.evaluate_potential_at_points(point_model.lattice)
-            fields = self.evaluate_field_at_points(point_model.lattice)
+            # reuse the located points, locating them is the expensive part
+            mesh_points = point_model.mesh_points
+            potentials = self.evaluate_potential_at_points(
+                point_model.lattice, mesh_points
+            )
+            fields = self.evaluate_field_at_points(point_model.lattice, mesh_points)
 
             # copy values for time-domain analysis
             self._copy_frequency_domain_solution(

--- a/ossdbs/point_analysis/pathway.py
+++ b/ossdbs/point_analysis/pathway.py
@@ -417,6 +417,7 @@ class Pathway(PointModel):
         grid_pts = self.points_in_mesh(mesh)
         self._lattice_mask = np.invert(grid_pts.mask)
         self._lattice = self.filter_for_geometry(grid_pts)
+        self.locate_lattice_in_mesh(mesh)
         self._inside_csf = self.get_points_in_csf(mesh, conductivity_cf)
         self._inside_encap = self.get_points_in_encapsulation_layer(mesh)
 

--- a/ossdbs/point_analysis/point_model.py
+++ b/ossdbs/point_analysis/point_model.py
@@ -22,6 +22,9 @@ _logger = logging.getLogger(__name__)
 class PointModel(ABC):
     """Class to support evaluation of VCM at points."""
 
+    # located mesh points of the filtered lattice, see locate_lattice_in_mesh
+    _mesh_points = None
+
     @property
     def name(self) -> str:
         """Name to distinguish model type."""
@@ -193,6 +196,41 @@ class PointModel(ABC):
         """Points inside encapsulation layer."""
         return self._inside_encap
 
+    @property
+    def mesh_points(self):
+        """Mesh points of :attr:`lattice` located in the mesh.
+
+        Notes
+        -----
+        Locating points in the mesh is by far the most expensive part of
+        the point analysis, while evaluating a CoefficientFunction on
+        already-located points is almost free. The points are therefore
+        located once in :meth:`locate_lattice_in_mesh` and reused by all
+        consumers (CSF / encapsulation masks, potential, electric field).
+        """
+        if self._mesh_points is None:
+            raise RuntimeError(
+                "Points have not been located in the mesh yet. "
+                "Please call first prepare_VCM_specific_evaluation "
+                "(or locate_lattice_in_mesh)."
+            )
+        return self._mesh_points
+
+    def locate_lattice_in_mesh(self, mesh: Mesh) -> None:
+        """Locate the filtered lattice in the mesh and cache the result.
+
+        Must be called after :attr:`lattice` has been set and after all
+        mesh refinements (including AMR) are complete, because the cached
+        mesh points are invalidated by any change of the mesh.
+
+        Parameters
+        ----------
+        mesh: Mesh
+            Mesh object on which VCM is defined
+        """
+        x, y, z = self.lattice.T
+        self._mesh_points = mesh.ngsolvemesh(x, y, z)
+
     def prepare_VCM_specific_evaluation(self, mesh: Mesh, conductivity_cf):
         """Prepare data structure according to mesh.
 
@@ -217,6 +255,7 @@ class PointModel(ABC):
         self._axon_index = np.reshape(
             np.arange(len(self.lattice)), (len(self.lattice), 1)
         )
+        self.locate_lattice_in_mesh(mesh)
         self._inside_csf = self.get_points_in_csf(mesh, conductivity_cf)
         self._inside_encap = self.get_points_in_encapsulation_layer(mesh)
 
@@ -306,9 +345,7 @@ class PointModel(ABC):
         encap_cf = mesh.ngsolvemesh.RegionCF(
             ngsolve.VOL, {"EncapsulationLayer_*": 1.0}, default=0
         )
-        ngmesh = mesh.ngsolvemesh
-        x, y, z = self.lattice.T
-        return np.isclose(encap_cf(ngmesh(x, y, z)), 1.0)
+        return np.isclose(encap_cf(self.mesh_points), 1.0)
 
     def get_points_in_csf(self, mesh: Mesh, conductivity_cf) -> np.ndarray:
         """Return mask for points in CSF.
@@ -325,15 +362,13 @@ class PointModel(ABC):
         TODO Type hint
         """
         material_distribution = conductivity_cf.material_distribution(mesh)
-        ngmesh = mesh.ngsolvemesh
-        x, y, z = self.lattice.T
         # always false (no CSF detected)
         csf_index = -1
         # only do real check when CSF is defined
         if "CSF" in conductivity_cf.materials:
             csf_index = conductivity_cf.materials["CSF"]
 
-        return np.isclose(material_distribution(ngmesh(x, y, z)), csf_index)
+        return np.isclose(material_distribution(self.mesh_points), csf_index)
 
     @property
     def output_path(self):


### PR DESCRIPTION
## Motivation

Locating points in the mesh is by far the most expensive part of the point analysis, while evaluating a `CoefficientFunction` on already located points is almost free. On a 500k-element mesh with a 71^3 lattice, locating 357,911 points takes ~5.9 s while evaluating four CoefficientFunctions on them takes 0.04 s.

The lattice was located afresh **four times** per frequency-domain evaluation, always for the same coordinates:

| call site | what it locates |
| --- | --- |
| `PointModel.get_points_in_csf` | `self.lattice` |
| `PointModel.get_points_in_encapsulation_layer` | `self.lattice` |
| `VolumeConductor.evaluate_potential_at_points` | `self.lattice` |
| `VolumeConductor.evaluate_field_at_points` | `self.lattice` |

For multi-frequency runs (PAM, octave bands) the last two are repeated for **every** frequency band.

This came out of a user report about a long, single-threaded wait after VTA computation. Both the mesh point search and the VTK export are fully serial in NGSolve: wall time is flat from 1 to 8 threads, so this block does not benefit from `TaskManager` at all and grows linearly with lattice size.

## Change

- Locate the lattice once in `prepare_VCM_specific_evaluation` and cache it; new `PointModel.mesh_points` property serves it and raises a clear error if accessed before preparation.
- `evaluate_potential_at_points` / `evaluate_field_at_points` accept the located points as an **optional** argument, so the signature documented in `docs/python_api.rst` keeps working unchanged.
- Vectorise the element-number check in `Mesh.not_included` (`mips["nr"] == -1` instead of a Python list comprehension over every point).

4 files, +75/-17. No changes to input files, settings or public API.

## Results (8 threads)

| case | before | after |
| --- | --- | --- |
| VTA, 71^3 lattice (356,765 points) | 37.0 s | **22.3 s** (-40%) |
| PAM example (28,935 axon points) | 9.1 s | **5.1 s** (-44%) |

Per phase for the 71^3 VTA case: `get_points_in_csf` 4.77 s -> 0.01 s, `get_points_in_encapsulation_layer` 4.65 s -> 0.00 s, `evaluate_potential_at_points` 4.78 s -> 0.01 s, `evaluate_field_at_points` 4.63 s -> 0.01 s.

PAM gains most because the evaluation runs once per frequency band, so the redundant lookups were repeated 12 times.

## Memory

The cached array is 40 byte per point: 1.2 MB for the PAM pathway, 14 MB for a 71^3 lattice. **Peak memory is unchanged**, because the same array was previously allocated and discarded on every call:

| | before | after |
| --- | --- | --- |
| VTA 71^3 | 4553 MB | 4550 MB |
| VTA 71^3, `OutOfCore: true` | 4537 MB | 4530 MB |

## Correctness

Output is unchanged:

- VTA niftis **byte-identical** at 51^3 and 71^3.
- Axon seeding identical (582/643 in the PAM example); pathway groups and axon names identical.
- `oss_potentials_*.csv`: `index`, coordinates, `inside_csf`, `inside_encap` and `frequency` columns all bit-identical.
- Field values differ by at most 4.0e-13, against a run-to-run noise floor of 2.9e-13 measured by running identical code twice (the parallel CG solver is not bit-reproducible).

Cache invalidation was checked explicitly. The cache is rebuilt whenever the lattice is, and AMR completes before `prepare_VCM_specific_evaluation`. The interesting case is `run_stim_sets`, which creates the point models once and then builds a new mesh per contact: instrumenting `input_case9` shows one point-model object across 4 distinct meshes with `locate_lattice_in_mesh` firing once per contact, plus 56 runtime assertions comparing the cached evaluation against a fresh locate on the current mesh, all bit-exact.

## Tests

Run against this branch's base:

- `pytest tests/` — 502 passed, 18 skipped
- Simulation tests, fast — 9 passed
- Simulation tests, slow — 7 passed, 1 failed
- Simulation tests, NEURON (`pam_standard`, `pam_out_of_core`, `pam_stimsets`) — 3 passed
- ruff 0.15.20 (the version pinned in `.pre-commit-config.yaml`) — all checks passed, all files formatted

### Note on the one failing test

`test_simulation[floating_impedance_noground]` fails with `max abs error=0.018971, max rel error=11.46%` on `floating_potentials.csv`. **This is pre-existing on `main` and unrelated to this PR.** Verified by stashing these changes and running the same test on a clean checkout of the base commit: identical error to every digit. That test's configuration also has no point model at all (`Lattice: false`, `VoxelLattice: null`, `Pathway: false`), so none of the code touched here executes in it. It needs a separate fix or a baseline refresh.

## Follow-ups (deliberately not in this PR)

1. `get_points_in_encapsulation_layer` uses the region pattern `"EncapsulationLayer_*"`, which NGSolve treats as a regex, so it means "EncapsulationLayer" followed by zero or more underscores and matches nothing. The mesh region is `EncapsulationLayer_1`, so `inside_encap` is currently **always all-False** and encapsulation points are never excluded. With `"EncapsulationLayer_.*"` the same test case finds 1,615 points. Kept separate because it changes numerical results and needs baseline updates.
2. `vtk_export` writes four separate VTU files, each re-writing the full mesh geometry (44.6 MB of points in a 69 MB `potential.vtu`). Combining them into one file and using `floatsize="single"` measured 332 MB -> 83 MB and 1.16 s -> 0.63 s on a 503k-element mesh.
3. An optional guard storing the mesh identity alongside the cache, so a future refactor that changes the mesh without re-preparing fails loudly instead of silently.
